### PR TITLE
fix: android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.syn_inc.flutter_nearby_connections'
     compileSdkVersion 34
 
     sourceSets {


### PR DESCRIPTION
Android Gradle Pluginが8.x.x.以上だとbuild.gradleでnamespaceが必要になったので指定した。