### PR TITLE
fix: omit package name

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.nankai.flutter_nearby_connections">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />


### PR DESCRIPTION
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
とのことなので修正。